### PR TITLE
fix: add gitignore safety check and validate all staged files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,11 @@ backups/
 # Temporary files and backups
 tmp
 backups
+
+# gcloud OAuth credentials (staged for deployment, never commit)
+roles/role-install-gcloud/files/credentials.db
+roles/role-install-gcloud/files/access_tokens.db
+roles/role-install-gcloud/files/active_config
+roles/role-install-gcloud/files/config_default
+roles/role-install-gcloud/files/google_compute_engine
+roles/role-install-gcloud/files/google_compute_engine.pub


### PR DESCRIPTION
## Summary
Follow-up to PR #35 addressing additional CodeRabbit feedback.

## Changes
- Add `git check-ignore` guard in `gcloud-credentials-stage` that fails if credentials would not be gitignored
- Validate all 6 required files before deployment (not just `credentials.db`)
- Add gitignore entries to main repo `.gitignore` (in addition to mkrasberry_config)

## Validation Added
The deploy target now checks for:
- `credentials.db`
- `access_tokens.db`
- `active_config`
- `config_default`
- `google_compute_engine`
- `google_compute_engine.pub`

If any are missing, a clear error message is shown instead of failing deep in Ansible.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a safety guard to prevent accidentally committing gcloud credentials and validates all required files before deployment. This reduces the risk of leaking secrets and fails fast with clear errors.

- **Bug Fixes**
  - Check that credentials are gitignored in mkrasberry_config before staging (git check-ignore). Abort with a helpful message if not.
  - Validate all six files before deploy: credentials.db, access_tokens.db, active_config, config_default, google_compute_engine, google_compute_engine.pub.
  - Add credentials file paths to the repo .gitignore to keep them out of commits.

<sup>Written for commit 4ee525b004beafd2d491b66fd9f48f1f7ed8c9a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository ignore rules to exclude additional temporary credential and config files.
  * Added pre-flight and deployment validations to ensure required credential/config files are properly staged and present before deployment.
  * Updated a referenced submodule to a newer commit for underlying workflow metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

PR #35のフィードバックに対応し、gcloud認証情報の安全性チェックとデプロイ前検証を強化しました。

主な変更点:
- `.gitignore`に6つのgcloud認証情報ファイルを追加（`credentials.db`、`access_tokens.db`、`active_config`、`config_default`、`google_compute_engine`、`google_compute_engine.pub`）
- `gcloud-credentials-stage`に`git check-ignore`による安全性チェックを追加
- `gcloud-credentials-deploy`で全6ファイルの存在を検証（以前は`credentials.db`のみ）

**重大な問題**:
61-63行目の`git check-ignore`チェックが`mkrasberry_config`サブモジュール内で実行されていますが、ファイルは実際にメインリポジトリの`roles/role-install-gcloud/files/`にコピーされます。サブモジュールには`roles/`ディレクトリが存在しないため、このセキュリティチェックは常に失敗し、正規のワークフローが機能しません。メインリポジトリでチェックを実行するように修正が必要です。

<h3>Confidence Score: 1/5</h3>

- 重大なロジックエラーにより、PRはマージ不可の状態です
- `gcloud-credentials-stage`のセキュリティチェックが間違ったディレクトリで実行されるため、常に失敗します。これにより正規の認証情報ステージングワークフローが完全にブロックされます。修正なしではこの機能は使用不可能です。
- Makefileの61-63行目を早急に修正する必要があります

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Makefile | `gcloud-credentials-stage`のgitignoreチェックロジックに重大な不具合、6ファイルの検証を追加 |
| .gitignore | gcloud認証情報ファイル6件の適切なgitignoreエントリを追加 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Make as Makefile
    participant Git as git check-ignore
    participant FS as File System
    participant Ansible

    User->>Make: make gcloud-credentials-stage
    Make->>Git: cd mkrasberry_config && check-ignore
    Git-->>Make: verify gitignore status
    alt Files not gitignored
        Make-->>User: Error: not git-ignored
    else Files gitignored
        Make->>FS: mkdir -p roles/role-install-gcloud/files
        Make->>FS: cp ~/.config/gcloud/* to roles/
        Make->>FS: cp ~/.ssh/google_compute_engine* to roles/
        Make-->>User: Credentials staged
    end
    
    User->>Make: make gcloud-credentials-deploy hostlist=X
    Make->>FS: test -f credentials.db
    Make->>FS: test -f access_tokens.db
    Make->>FS: test -f active_config
    Make->>FS: test -f config_default
    Make->>FS: test -f google_compute_engine
    Make->>FS: test -f google_compute_engine.pub
    alt Any file missing
        Make-->>User: Error: file not staged
    else All files present
        Make->>Ansible: deploy credentials via playbook
        Ansible-->>User: Deployment complete
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->