### PR TITLE
This is a fix for broken rfkill

### DIFF
--- a/.beads/issues.jsonl
+++ b/.beads/issues.jsonl
@@ -1,0 +1,1 @@
+{"id":"mkrasberry-iyz","title":"We want to get back to using qemu to build 90% pre-installed images, leaving last mile customization","status":"open","priority":2,"issue_type":"task","created_at":"2026-01-26T02:54:38.730611-05:00","created_by":"njl","updated_at":"2026-01-26T02:54:38.730611-05:00"}

--- a/roles/wifiClientSetup/meta/main.yml
+++ b/roles/wifiClientSetup/meta/main.yml
@@ -5,7 +5,7 @@ dependencies: []
 galaxy_info:
   author: Nick Lange
   company: Private
-  description: Configures Raspberry PI wifi
+  description: Configures Raspberry PI wifi and ensures wifi/bluetooth radios are unblocked via rfkill
   license: MIT
   platforms:
   - name: Debian

--- a/roles/wifiClientSetup/tasks/install.yml
+++ b/roles/wifiClientSetup/tasks/install.yml
@@ -41,6 +41,11 @@
   when:     wpa_supplicant_updated is defined
 #    cron_file: phoneHome_sh
 
+- name: ensure bluetooth is unblocked via rfkill
+  shell: rfkill unblock bluetooth
+  when: wpa_supplicant_updated is defined
+  changed_when: false
+
 
 #- name: configure service for systemd
 #  template:
@@ -61,6 +66,8 @@
 - name: reload the config
   shell: wpa_cli -i wlan0 reconfigure
   when:     wpa_supplicant_updated is defined
+  register: wpa_cli_reconfigure
+  failed_when: false
 #    cron_file: phoneHome_sh
 
 - name: up the wlan0 interface


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Unblocks Bluetooth via rfkill during Wi‑Fi client setup and makes wpa_cli reconfigure resilient, fixing setup failures caused by blocked radios.

- **Bug Fixes**
  - Run "rfkill unblock bluetooth" during setup; idempotent and avoids false change reports.
  - Make "wpa_cli -i wlan0 reconfigure" non-fatal and capture output for debugging.
  - Update role description to note rfkill behavior.

<sup>Written for commit a9d119e4f44e31a1e2583acd216fe67a07ebbdd2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WiFi setup now ensures Bluetooth and WiFi radios are properly unblocked for connectivity.

* **Bug Fixes**
  * Improved error handling in network configuration processes to prevent failures on non-critical errors.

* **Chores**
  * Updated infrastructure documentation and task tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Raspberry PIのwifi/bluetooth radiosを正しくunblockするための修正。`rfkill unblock bluetooth`コマンドを追加し、`wpa_cli reconfigure`のエラー処理を改善（`failed_when: false`追加）した。

主な変更:
- bluetoothのrfkill unblock処理を追加（line 44-47）
- `wpa_cli reconfigure`がfailしても処理を続行するように設定
- metadataのdescriptionにrfkill機能を明記

<h3>Confidence Score: 4/5</h3>

- rfkill修正は安全だが、wifi/bluetoothのunblock処理の一貫性を改善できる
- 変更はシンプルで問題ない。bluetoothのunblockとエラー処理の改善は適切。ただし、wifi unblockとbluetooth unblockの`changed_when`設定に不一致がある
- `roles/wifiClientSetup/tasks/install.yml`のwifi/bluetooth unblock処理の一貫性確認

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| roles/wifiClientSetup/tasks/install.yml | bluetoothのunblock処理を追加、wpa_cli reconfigureのエラー処理を改善 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Ansible
    participant wlan0
    participant rfkill
    participant wpa_supplicant
    participant wpa_cli

    Ansible->>wpa_supplicant: wpa_supplicant.confをインストール
    Ansible->>wlan0: ip link set wlan0 down
    Ansible->>rfkill: rfkill unblock wifi
    Ansible->>rfkill: rfkill unblock bluetooth (新規追加)
    Note over rfkill: wifi/bluetooth radiosをunblock
    Ansible->>wpa_supplicant: サービスをenable & start
    Ansible->>wpa_cli: wpa_cli reconfigure (エラー無視)
    Note over wpa_cli: failed_when: falseで失敗を許容
    Ansible->>wlan0: ip link set wlan0 up
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->